### PR TITLE
Add interpreter and cleanup imports + carriage returns

### DIFF
--- a/PVEDiscordDark.py
+++ b/PVEDiscordDark.py
@@ -1,13 +1,15 @@
-import sys,os
+#!/usr/bin/python3
+
+import os
+import sys
+import time
 import subprocess
 import urllib.request
 import os.path
 import shutil
 import argparse
-import os
-import time
 
-ACTION = None 
+ACTION = None
 
 images = [
     'dd_cephblurp.png', 'dd_cephwhite.png',
@@ -180,7 +182,7 @@ def main():
             print('\n')
             exit(0)
     else:
-        if ACTION == 'install': 
+        if ACTION == 'install':
             installTheme()
         else:
             if themeIsInstalled():


### PR DESCRIPTION
1) Added interpreter #!/usr/bin/python3 to allow for running as ./PVEDiscordDark.py
2) Remove redundant import of os after sys
3) Cleaned up carriage return characters ^M from file to resolve the following error: -bash: ./PVEDiscordDark.py: /usr/bin/python3^M: bad interpreter: No such file or directory