### PR TITLE
Fix fallback font in `.x-body`

### DIFF
--- a/PVEDiscordDark/sass/x/_body.sass
+++ b/PVEDiscordDark/sass/x/_body.sass
@@ -3,5 +3,5 @@
 	font-size: 13px
 	line-height: 17px
 	font-weight: 300
-	font-family: 'helvetica', 'arial', 'verdana', 'sans-serif'
+	font-family: 'helvetica', 'arial', 'verdana', sans-serif
 	background: #fff


### PR DESCRIPTION
As you can see in this screenshot, my browser is falling back to a default serif font:

![Proxmox dark theme with a serif font](https://user-images.githubusercontent.com/1362179/170842943-210b98f9-7eef-4450-834d-5130fc00d237.png)

From the [MDN docs on the `font-family` property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#syntax) (emphasis added):

> Generic font families are a fallback mechanism, a means of preserving some of the style sheet author's intent when none of the specified fonts are available. **Generic family names are keywords and must not be quoted**. [...]

This PR tweaks the fallback font for the `.x-body` style to use `sans-serif` instead of `'sans-serif'`, which should fix this issue.

